### PR TITLE
feat: create custom query to generate number of txs

### DIFF
--- a/api/src/tasks/generateDataStats.ts
+++ b/api/src/tasks/generateDataStats.ts
@@ -7,7 +7,7 @@ import { generateActiveAddressesPerDay } from "./generateActiveAddressesPerDay";
 export async function generateDataStats() {
   const currentData = readData();
   console.log("Starting number of transactions...");
-  const nbTxsPerDay = await generateNbTxsPerDay(currentData?.nbTxsPerDay);
+  const nbTxsPerDay = await generateNbTxsPerDay();
   console.log("Number of transactions generated");
 
   console.log("Starting number of unique addresses...");

--- a/api/src/tasks/generateNbTxsPerDay.ts
+++ b/api/src/tasks/generateNbTxsPerDay.ts
@@ -1,44 +1,15 @@
-import { addDays, isBefore, format, isSameDay } from "date-fns";
 import { prisma } from "../prisma";
 import { Result } from "../types/FileData";
-import { startDate } from "../utils";
 
-export async function generateNbTxsPerDay(currentData: Result[] | undefined) {
-  const endDate = new Date();
-  // We take latest date of from dates already recorded and make
-  // it the iterator date
-  let iteratorDate = currentData
-    ? new Date(currentData[currentData.length - 1].date)
-    : startDate;
-  const result: Result[] = currentData ?? [];
-
-  // We remove the last day to make sure that if server restarts on same
-  // day the latest data is overwritten
-  if (
-    currentData &&
-    isSameDay(new Date(currentData[currentData.length - 1].date), endDate)
-  ) {
-    currentData.pop();
-  }
-
-  // Loop day by day between both dates
-  while (isBefore(iteratorDate, endDate)) {
-    const dayAfter = addDays(iteratorDate, 1);
-
-    const transactionsCount = await prisma.txs.count({
-      where: {
-        burn_block_time: {
-          gte: iteratorDate.getTime() / 1000,
-          lt: dayAfter.getTime() / 1000,
-        },
-      },
-    });
-
-    const dateFormatted = format(iteratorDate, "yyyy-MM-dd");
-    result.push({ date: dateFormatted, value: transactionsCount });
-
-    iteratorDate = addDays(iteratorDate, 1);
-  }
-
+/**
+ * Generate the number of transactions per day.
+ * "burn_block_time" is stored as an integer, so we have to convert it to timestamp
+ * then to date.
+ */
+export async function generateNbTxsPerDay() {
+  const result = await prisma.$queryRaw<Result[]>`
+  select to_timestamp(burn_block_time)::date as "date", count(*) as "value" from txs 
+    where to_timestamp(burn_block_time)::date between '2021-01-01' and current_date
+      group by 1`;
   return result;
 }


### PR DESCRIPTION
Create a custom SQL query to generate the number of transactions per day.
Old way execution time: `180s 495.067354ms`
New query execution time: `1s 359.967724ms`

The new way is 180 times faster 🤯 

Measured with:

```ts
  var hrstart = process.hrtime();
  const txsFeePerDay = await generateTxsFeePerDay();
  var hrend = process.hrtime(hrstart);
  console.info("Execution time (hr): %ds %dms", hrend[0], hrend[1] / 1000000);
```