### PR TITLE
feat: create custom query to generate the fees per day

### DIFF
--- a/api/src/tasks/generateDataStats.ts
+++ b/api/src/tasks/generateDataStats.ts
@@ -15,7 +15,7 @@ export async function generateDataStats() {
   console.log("Number of unique addresses generated");
 
   console.log("Starting total fees...");
-  const txsFeePerDay = await generateTxsFeePerDay(currentData?.txsFeePerDay);
+  const txsFeePerDay = await generateTxsFeePerDay();
   console.log("Total fees generated");
 
   console.log("Starting number of active addresses...");

--- a/api/src/tasks/generateTxsFeePerDay.ts
+++ b/api/src/tasks/generateTxsFeePerDay.ts
@@ -1,52 +1,10 @@
-import { addDays, isBefore, format, isSameDay } from "date-fns";
 import { prisma } from "../prisma";
 import { Result } from "../types/FileData";
-import { startDate } from "../utils";
 
-export async function generateTxsFeePerDay(currentData: Result[] | undefined) {
-  const endDate = new Date();
-  // We take latest date of from dates already recorded and make
-  // it the iterator date
-  let iteratorDate = currentData
-    ? new Date(currentData[currentData.length - 1].date)
-    : startDate;
-  const result: Result[] = currentData ?? [];
-
-  // We remove the last day to make sure that if server restarts on same
-  // day the latest data is overwritten
-  if (
-    currentData &&
-    isSameDay(new Date(currentData[currentData.length - 1].date), endDate)
-  ) {
-    currentData.pop();
-  }
-
-  // Loop day by day between both dates
-  while (isBefore(iteratorDate, endDate)) {
-    const dayAfter = addDays(iteratorDate, 1);
-
-    const transactions = await prisma.txs.findMany({
-      where: {
-        burn_block_time: {
-          gte: iteratorDate.getTime() / 1000,
-          lt: dayAfter.getTime() / 1000,
-        },
-      },
-      select: {
-        fee_rate: true,
-      },
-    });
-
-    let totalFee = BigInt(0);
-    transactions.forEach((transaction) => {
-      totalFee += transaction.fee_rate;
-    });
-
-    const dateFormatted = format(iteratorDate, "yyyy-MM-dd");
-    result.push({ date: dateFormatted, value: Number(totalFee) });
-
-    iteratorDate = addDays(iteratorDate, 1);
-  }
-
+export async function generateTxsFeePerDay() {
+  const result = await prisma.$queryRaw<Result[]>`
+  select to_timestamp(burn_block_time)::date as "date", sum(fee_rate) as "value" from txs 
+    where to_timestamp(burn_block_time)::date between '2021-01-01' and current_date
+      group by 1`;
   return result;
 }


### PR DESCRIPTION
Create a custom SQL query to generate the fees per day.
Old way execution time: `19s 451.477879ms`
New query execution time: `1s 294.656516ms`

Almost 19 times faster.