### PR TITLE
feat: cache api results

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -2,6 +2,8 @@
 
 This service is responsible of generating the data used by the client. It expose this data via the http protocol on port 4000.
 
+A public API is available at https://api.stxstats.co/, note that the data is updated every 2 minutes.
+
 ## Endpoints
 
 ### Daily transactions count

--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
     "envalid": "7.2.2",
     "fastify": "3.24.1",
     "ioredis": "4.27.7",
+    "node-cache": "5.1.2",
     "node-fetch": "2.6.1",
     "prisma": "3.8.1",
     "twit": "2.2.11"

--- a/api/src/api/cache.ts
+++ b/api/src/api/cache.ts
@@ -1,0 +1,4 @@
+import NodeCache from 'node-cache';
+
+// Cache API result for 2 minutes
+export const apiCache = new NodeCache({ stdTTL: 120 });

--- a/api/src/api/dailyTransactions.ts
+++ b/api/src/api/dailyTransactions.ts
@@ -1,16 +1,26 @@
-import { FastifyReply } from 'fastify';
+import { FastifyReply, FastifyRequest } from 'fastify';
 import { prisma } from '../prisma';
+import { apiCache } from './cache';
 
 interface DataResponse {
   date: string;
   txCount: number;
 }
 
-export async function dailyTransactions(_: unknown, reply: FastifyReply) {
-  const result = await prisma.$queryRaw<DataResponse[]>`
+export async function dailyTransactions(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  const apiRoute = request.routerPath;
+  if (apiCache.has(apiRoute)) {
+    return reply.send(apiCache.get(apiRoute));
+  }
+
+  const response = await prisma.$queryRaw<DataResponse[]>`
   select to_timestamp(burn_block_time)::date as "date", count(*) as "txCount" from txs 
     where to_timestamp(burn_block_time)::date between '2021-01-01' and current_date
       group by 1`;
 
-  reply.send(result);
+  apiCache.set(apiRoute, response);
+  reply.send(response);
 }

--- a/api/src/api/dailyTransactionsNetworkFees.ts
+++ b/api/src/api/dailyTransactionsNetworkFees.ts
@@ -1,5 +1,6 @@
-import { FastifyReply } from 'fastify';
+import { FastifyReply, FastifyRequest } from 'fastify';
 import { prisma } from '../prisma';
+import { apiCache } from './cache';
 
 interface DataResponse {
   date: string;
@@ -7,13 +8,19 @@ interface DataResponse {
 }
 
 export async function dailyTransactionsNetworkFees(
-  _: unknown,
+  request: FastifyRequest,
   reply: FastifyReply
 ) {
-  const result = await prisma.$queryRaw<DataResponse[]>`
+  const apiRoute = request.routerPath;
+  if (apiCache.has(apiRoute)) {
+    return reply.send(apiCache.get(apiRoute));
+  }
+
+  const response = await prisma.$queryRaw<DataResponse[]>`
   select to_timestamp(burn_block_time)::date as "date", sum(fee_rate) as "txFee" from txs 
     where to_timestamp(burn_block_time)::date between '2021-01-01' and current_date
       group by 1`;
 
-  reply.send(result);
+  apiCache.set(apiRoute, response);
+  reply.send(response);
 }

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -97,7 +97,7 @@ const Dashboard = ({ stxStats }: DashboardProps) => {
   );
 };
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   const res = await fetch(`${process.env.API_URL!}/dashboard`);
   const stxStats = await res.json();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ importers:
       envalid: 7.2.2
       fastify: 3.24.1
       ioredis: 4.27.7
+      node-cache: 5.1.2
       node-fetch: 2.6.1
       nodemon: 2.0.15
       prisma: 3.8.1
@@ -41,6 +42,7 @@ importers:
       envalid: 7.2.2
       fastify: 3.24.1
       ioredis: 4.27.7
+      node-cache: 5.1.2
       node-fetch: 2.6.1
       prisma: 3.8.1
       twit: 2.2.11
@@ -1585,6 +1587,11 @@ packages:
     dependencies:
       mimic-response: 1.0.1
     dev: true
+
+  /clone/2.1.2:
+    resolution: {integrity: sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=}
+    engines: {node: '>=0.8'}
+    dev: false
 
   /cluster-key-slot/1.1.0:
     resolution: {integrity: sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==}
@@ -3620,6 +3627,13 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - webpack
+    dev: false
+
+  /node-cache/5.1.2:
+    resolution: {integrity: sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      clone: 2.1.2
     dev: false
 
   /node-fetch/2.6.1:


### PR DESCRIPTION
This pr cache the API results for 2 minutes, this will allow the client to call the API every time it's called without creating issues for the API. 